### PR TITLE
Accept vendor-specific protocol buffer Accept headers.

### DIFF
--- a/src/Nancy.Serialization.ProtoBuf.Tests/ProtoBufNancySerializationFixture.cs
+++ b/src/Nancy.Serialization.ProtoBuf.Tests/ProtoBufNancySerializationFixture.cs
@@ -14,6 +14,7 @@
     {
         private const string UserName = "testUser";
         private const int UserAge = 29;
+		private const string VendorContentType = "application/vnd.company.product.v1+x-protobuf";
 
         static ProtoBufNancySerializationFixture()
         {
@@ -39,6 +40,26 @@
             CheckResponse(response, UserName, UserAge);
         }
 
+		[Fact]
+		public void TestGetWithVendorContentType()
+		{
+			// Given
+			var bootstrapper = new DefaultNancyBootstrapper();
+			var browser = new Browser(bootstrapper);
+			var url = string.Format("/getProtoBuf/{0}/{1}", UserName, UserAge);
+
+			// When
+			var response = browser.Get(url, with =>
+			{
+				with.HttpRequest();
+				
+				with.Accept(VendorContentType);
+			});
+
+			// Then
+			CheckResponse(response, UserName, UserAge);
+		}
+
         [Fact]
         public void TestPost()
         {
@@ -58,6 +79,26 @@
             // Then
             CheckResponse(response, UserName, UserAge);
         }
+
+		[Fact]
+		public void TestPostWithVendorContentType()
+		{
+			// Given
+			var bootstrapper = new DefaultNancyBootstrapper();
+			var browser = new Browser(bootstrapper);
+
+			// When
+			var response = browser.Post("/postProtoBuf", with =>
+			{
+				with.HttpRequest();
+				with.FormValue("Name", UserName);
+				with.FormValue("Age", UserAge.ToString());
+				with.Accept(VendorContentType);
+			});
+
+			// Then
+			CheckResponse(response, UserName, UserAge);
+		}
 
         private static void CheckResponse(BrowserResponse response, string name, int age)
         {

--- a/src/Nancy.Serialization.ProtoBuf/BodyDeserializers/ProtobufNetBodyDeserializer.cs
+++ b/src/Nancy.Serialization.ProtoBuf/BodyDeserializers/ProtobufNetBodyDeserializer.cs
@@ -53,21 +53,21 @@ namespace Nancy.Serialization.ProtoBuf.BodyDeserializers
 
             var contentMimeType = contentType.Split(';').First();
 
-			// We probably have something like application/x-protobuf OR
-			// application/vnd.whatever+x-protobuf
+		// We probably have something like application/x-protobuf OR
+		// application/vnd.whatever+x-protobuf
 
-			// accept them all!
+		// accept them all!
 	        try
 	        {
-				// Are we just application/x-protobuf?
+			// Are we just application/x-protobuf?
 		        if (contentMimeType.Equals(Constants.ProtoBufContentType, StringComparison.InvariantCultureIgnoreCase))
 			        return true;
 				
-				// Ok, get a little more creative and look for the specific vendor flavor:
-				string fSubType = contentMimeType.Split('/').Skip(1).First();
+			// Ok, get a little more creative and look for the specific vendor flavor:
+			string fSubType = contentMimeType.Split('/').Skip(1).First();
 
-				return (fSubType.StartsWith("vnd", StringComparison.InvariantCultureIgnoreCase) &&
-						fSubType.EndsWith("+x-protobuf", StringComparison.InvariantCultureIgnoreCase));
+			return (fSubType.StartsWith("vnd", StringComparison.InvariantCultureIgnoreCase) &&
+				fSubType.EndsWith("+x-protobuf", StringComparison.InvariantCultureIgnoreCase));
 	        }
 	        catch (Exception)
 	        {

--- a/src/Nancy.Serialization.ProtoBuf/BodyDeserializers/ProtobufNetBodyDeserializer.cs
+++ b/src/Nancy.Serialization.ProtoBuf/BodyDeserializers/ProtobufNetBodyDeserializer.cs
@@ -53,8 +53,26 @@ namespace Nancy.Serialization.ProtoBuf.BodyDeserializers
 
             var contentMimeType = contentType.Split(';').First();
 
-            return contentMimeType.Equals(
-                Constants.ProtoBufContentType, StringComparison.InvariantCultureIgnoreCase);
+			// We probably have something like application/x-protobuf OR
+			// application/vnd.whatever+x-protobuf
+
+			// accept them all!
+	        try
+	        {
+				// Are we just application/x-protobuf?
+		        if (contentMimeType.Equals(Constants.ProtoBufContentType, StringComparison.InvariantCultureIgnoreCase))
+			        return true;
+				
+				// Ok, get a little more creative and look for the specific vendor flavor:
+				string fSubType = contentMimeType.Split('/').Skip(1).First();
+
+				return (fSubType.StartsWith("vnd", StringComparison.InvariantCultureIgnoreCase) &&
+						fSubType.EndsWith("+x-protobuf", StringComparison.InvariantCultureIgnoreCase));
+	        }
+	        catch (Exception)
+	        {
+		        return false;
+	        }
         }
     }
 }

--- a/src/Nancy.Serialization.ProtoBuf/ProtoBufProcessor.cs
+++ b/src/Nancy.Serialization.ProtoBuf/ProtoBufProcessor.cs
@@ -30,7 +30,7 @@
         /// <returns>A <see cref="ProcessorMatch"/> result that determines the priority of the processor.</returns>
         public ProcessorMatch CanProcess(MediaRange requestedMediaRange, dynamic model, NancyContext context)
         {
-            if (IsWildcard(requestedMediaRange) || requestedMediaRange.Matches(Constants.ProtoBufContentType))
+            if (IsWildcardProtobufContentType(requestedMediaRange) || requestedMediaRange.Matches(Constants.ProtoBufContentType))
             {
                 return new ProcessorMatch
                 {
@@ -58,9 +58,20 @@
             return new ProtoBufResponse(model);
         }
         
-        private static bool IsWildcard(MediaRange requestedMediaRange)
+        private static bool IsWildcardProtobufContentType(MediaRange requestedContentType)
         {
-            return requestedMediaRange.Type.IsWildcard && requestedMediaRange.Subtype.IsWildcard;
+			if (!requestedContentType.Type.IsWildcard && !string.Equals("application", requestedContentType.Type, StringComparison.InvariantCultureIgnoreCase))
+			{
+				return false;
+			}
+			if (requestedContentType.Subtype.IsWildcard)
+			{
+				return true;
+			}
+			var subtypeString = requestedContentType.Subtype.ToString();
+
+			return (subtypeString.StartsWith("vnd", StringComparison.InvariantCultureIgnoreCase) &&
+			subtypeString.EndsWith("+x-protobuf", StringComparison.InvariantCultureIgnoreCase));
         }
     }
 }


### PR DESCRIPTION
If the request contained an Accepts header of the form: application/vnd.SOMETHING+x-protobuf, the framework wouldn't recognize it. This broke bind() calls among others.

I lifted the idea for this implementation from another Nancy serializer, but I can't remember where (sorry, I hacked this internally for a project a while ago and I'm just now getting around to sending my patch upstream).

I've also added a few unit tests to verify this behavior. Let me know if I need to tweak this to make the patch acceptable.